### PR TITLE
Move `Plug` related things to `/lib/plug`.

### DIFF
--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -1,4 +1,4 @@
-defmodule Pipeline.Router do
+defmodule Pipeline.Plug.Router do
   @moduledoc """
   Just like Plug's Router!
 

--- a/lib/plug/util.ex
+++ b/lib/plug/util.ex
@@ -1,4 +1,4 @@
-defmodule Pipeline.Util do
+defmodule Pipeline.Plug.Util do
   @doc """
   Set the contents of the response body. Unfortunately Plug has no function
   to do this natively (you're always forced to set the status too) so we have


### PR DESCRIPTION
These might end up being deleted at some point anyway, but keeping more stuff out of the "core" bits makes sense.
